### PR TITLE
Moved Bruiser and Demolisher under Items

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -67,10 +67,10 @@
         * [Steel Barrel](/items/cannon/steelbarrel.md)
         * [Sinker's Gloves](/items/cannon/sinkersgloves.md)
         * [Blue Gunpowder](/items/cannon/bluegunpowder.md)
-        * Hybrid
-            * [Drifter](/items/cannon/hybrid/drifter.md)
-            * [Bruiser](/items/cannon/hybrid/bruiser.md)
-            * [Demolisher](/items/cannon/hybrid/demolisher.md)
+        * [Bruiser](/items/cannon/bruiser.md)
+        * [Demolisher](/items/cannon/demolisher.md)
+    * Hybrid
+        * [Drifter](/items/cannon/hybrid/drifter.md)
 ---
 * [Cargo](/cargo.md)
     * [Rum](/cargo/rum.md)

--- a/docs/items/cannon/bruiser.md
+++ b/docs/items/cannon/bruiser.md
@@ -1,6 +1,6 @@
 |Title      | Bruiser      
 |:-|-:
-|Type       | Canon          
+|Type       | Cannon          
 |Effects    | +10% [Fire Rate](gameplay/upgrades/firerate.md) & +4 [Damage](gameplay/upgrades/damage.md)
 |Price      | 20k [Gold](gold.md)
 |Islands    | [Brazil](gameplay/islands/brazil.md) & [Spain](gameplay/islands/spain.md)          

--- a/docs/items/cannon/bruiser.md
+++ b/docs/items/cannon/bruiser.md
@@ -1,6 +1,6 @@
 |Title      | Bruiser      
 |:-|-:
-|Type       | Hybrid          
+|Type       | Canon          
 |Effects    | +10% [Fire Rate](gameplay/upgrades/firerate.md) & +4 [Damage](gameplay/upgrades/damage.md)
 |Price      | 20k [Gold](gold.md)
 |Islands    | [Brazil](gameplay/islands/brazil.md) & [Spain](gameplay/islands/spain.md)          

--- a/docs/items/cannon/demolisher.md
+++ b/docs/items/cannon/demolisher.md
@@ -1,6 +1,6 @@
 |Title      | Demolisher      
 |:-|-:
-|Type       | Hybrid          
+|Type       | Cannon         
 |Effects    |  +25% [Fire Rate](gameplay/upgrades/firerate.md) & +4 [Damage](gameplay/upgrades/damage.md)
 |Price      | 100k [Gold](gold.md)
 |Islands    | [Jamaica](gameplay/islands/jamaica.md)


### PR DESCRIPTION
Moved Bruiser and Demolisher from Hybrid to under Cannon. They only affect the cannon.
Kept Drifter under Hybrid as it is a  hybrid of a ship and cannon upgrade.